### PR TITLE
Add some top-level package docs

### DIFF
--- a/appdirs/appdirs.pony
+++ b/appdirs/appdirs.pony
@@ -1,3 +1,10 @@
+"""
+# AppDirs
+
+Library for detecting platform specific user directories e.g. for data, config, cache, logs.
+
+Most stuff is copied from the python library [appdirs](https://github.com/ActiveState/appdirs) from ActiveState.
+"""
 use "files"
 use "cli" // for EnvVars
 use "itertools"


### PR DESCRIPTION
It will look much better in the docs to have some sort of
description at the top level of what the library does.

This is the bare minimum, it would be great if we could get more
with examples etc.