### PR TITLE
Update to match breaking API change in the pony standard library

### DIFF
--- a/.release-notes/31.md
+++ b/.release-notes/31.md
@@ -1,0 +1,3 @@
+## Forward prepare for coming breaking change in ponyc
+
+This change has no impact on end users, but will future proof against a coming breaking change in the standard library. Users of this version of the library won't be impacted by the coming change.

--- a/appdirs/_test.pony
+++ b/appdirs/_test.pony
@@ -116,7 +116,7 @@ class AppDirsDefaultsTest is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let env_vars = [
-      "HOME=" + _AppDirsTestUtil.test_home()
+      as String: "HOME=" + _AppDirsTestUtil.test_home()
     ]
     let app_dirs = AppDirs(env_vars, "appdirs")
     let expected =
@@ -159,7 +159,7 @@ class AppDirsVersionTest is UnitTest
   fun name(): String => "appdirs/version"
   fun apply(h: TestHelper) ? =>
     let env_vars = [
-      "HOME=" + _AppDirsTestUtil.test_home()
+      as String: "HOME=" + _AppDirsTestUtil.test_home()
     ]
     let app_dirs = AppDirs(env_vars, "appdirs" where app_version="0.4")
     let expected =
@@ -244,7 +244,7 @@ class AppDirsAppAuthorTest is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let env_vars = [
-      "HOME=" + _AppDirsTestUtil.test_home()
+      as String: "HOME=" + _AppDirsTestUtil.test_home()
     ]
     let app_dirs = AppDirs(env_vars, "appdirs", "Matthias Wahl")
     let expected =
@@ -288,7 +288,7 @@ class AppDirsWindowsRoamingTest is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let env_vars = [
-      "HOME=" + _AppDirsTestUtil.test_home()
+      as String: "HOME=" + _AppDirsTestUtil.test_home()
     ]
     let app_dirs = AppDirs(env_vars, "appdirs" where roaming = true)
     let expected =


### PR DESCRIPTION
This change is backwards compatible with ponyc 0.40.0
