### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/appdirs/_test.pony
+++ b/appdirs/_test.pony
@@ -54,7 +54,7 @@ primitive \nodoc\ _AppDirsTestUtil
     h: TestHelper,
     loc: SourceLoc = __loc) ?
   =>
-    match expected.home_dir
+    match \exhaustive\ expected.home_dir
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.user_home_dir()? }
@@ -65,7 +65,7 @@ primitive \nodoc\ _AppDirsTestUtil
         app_dirs.user_home_dir()?
         where loc = loc)
     end
-    match expected.user_data_dir
+    match \exhaustive\ expected.user_data_dir
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.user_data_dir()? }
@@ -76,7 +76,7 @@ primitive \nodoc\ _AppDirsTestUtil
         app_dirs.user_data_dir()?
         where loc = loc)
     end
-    match expected.site_data_dirs
+    match \exhaustive\ expected.site_data_dirs
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.site_data_dirs()? }
@@ -88,7 +88,7 @@ primitive \nodoc\ _AppDirsTestUtil
         where loc = loc)
     end
 
-    match expected.user_config_dir
+    match \exhaustive\ expected.user_config_dir
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.user_config_dir()? }
@@ -99,7 +99,7 @@ primitive \nodoc\ _AppDirsTestUtil
         app_dirs.user_config_dir()?
         where loc = loc)
     end
-    match expected.site_config_dirs
+    match \exhaustive\ expected.site_config_dirs
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.site_config_dirs()? }
@@ -111,7 +111,7 @@ primitive \nodoc\ _AppDirsTestUtil
         where loc = loc)
     end
 
-    match expected.user_cache_dir
+    match \exhaustive\ expected.user_cache_dir
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.user_cache_dir()? }
@@ -123,7 +123,7 @@ primitive \nodoc\ _AppDirsTestUtil
         where loc = loc)
     end
 
-    match expected.user_state_dir
+    match \exhaustive\ expected.user_state_dir
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.user_state_dir()? }
@@ -135,7 +135,7 @@ primitive \nodoc\ _AppDirsTestUtil
         where loc = loc)
     end
 
-    match expected.user_log_dir
+    match \exhaustive\ expected.user_log_dir
     | _ExpectError =>
       h.assert_error(
         {()? => app_dirs.user_log_dir()? }

--- a/appdirs/appdirs.pony
+++ b/appdirs/appdirs.pony
@@ -37,7 +37,7 @@ type _Maybe[T] is (T | None)
 
 primitive _Opt
   fun get[T](s: _Maybe[T], or_else: T): T =>
-    match consume s
+    match \exhaustive\ consume s
     | let value: T => consume value
     | None => consume or_else
     end
@@ -126,7 +126,7 @@ class AppDirs
     dir for this application.
     """
     let os_specific_dir =
-      match _platform
+      match \exhaustive\ _platform
       | _Osx =>
         Paths.join(
           [ _home as String
@@ -153,7 +153,7 @@ class AppDirs
           ""
         end
       end
-    match _app_version
+    match \exhaustive\ _app_version
     | None => os_specific_dir
     | let v: String => Path.join(os_specific_dir, v)
     end
@@ -175,7 +175,7 @@ class AppDirs
     data dirs for this application.
     """
     let os_specific_dirs: Array[String] iso =
-      match _platform
+      match \exhaustive\ _platform
       | _Osx =>
         recover
           [ Path.join(
@@ -239,7 +239,7 @@ class AppDirs
     for this application.
     """
     let os_specific_dir =
-      match _platform
+      match \exhaustive\ _platform
       | _Osx =>
         Paths.join(
           [ _home as String
@@ -254,7 +254,7 @@ class AppDirs
       end
 
     // apply version
-    match _app_version
+    match \exhaustive\ _app_version
     | None => os_specific_dir
     | let v: String =>
       Path.join(os_specific_dir, v)
@@ -275,7 +275,7 @@ class AppDirs
     for this application.
     """
     let os_specific_dirs: Array[String] iso =
-      match _platform
+      match \exhaustive\ _platform
       | _Osx =>
         recover
           [ Path.join(
@@ -326,7 +326,7 @@ class AppDirs
     for this application.
     """
     let os_specific_dir =
-      match _platform
+      match \exhaustive\ _platform
       | _Osx =>
         Paths.join(
           [ _home as String
@@ -351,7 +351,7 @@ class AppDirs
           ""
         end
       end
-    match _app_version
+    match \exhaustive\ _app_version
     | None => os_specific_dir
     | let v: String => Path.join(os_specific_dir, v)
     end
@@ -371,7 +371,7 @@ class AppDirs
     See:
     https://wiki.debian.org/XDGBaseDirectorySpecification#state
     """
-    match _platform
+    match \exhaustive\ _platform
     | _Osx | _Windows =>
       user_data_dir()?
     | _OsxAsUnix | _Unix =>
@@ -393,7 +393,7 @@ class AppDirs
     Return full path to the user-specific log dir
     for this application.
     """
-    match _platform
+    match \exhaustive\ _platform
     | _Osx =>
       Paths.join(
         [ _home as String


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.