### PR TITLE
Update macOS runner to macos-26

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
 
   vs-ponyc-release-macOS-x86_64:
     name: Test against recent ponyc release on x86-64 macOS
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install dependencies


### PR DESCRIPTION
macOS 26 runners are now generally available for GitHub Actions.

Update arm64 macOS runner from macos-15 to macos-26.