### PR TITLE
Update actionlint Docker image to 20260311

### DIFF
--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Check workflow files
-        uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260120
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:
           args: -color


### PR DESCRIPTION
Update shared-docker-ci-actionlint image to pick up macos-26-intel runner label support.