### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,8 @@ jobs:
     name: Test against recent ponyc release on Windows
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |


### PR DESCRIPTION
Disable Windows Defender real-time monitoring as the first step in all Windows CI jobs.