### PR TITLE
Add Windows nightly breakage test

### DIFF
--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -1,4 +1,4 @@
-name: ponyc update breakage test
+name: Linux ponyc update breakage test
 
 on:
   repository_dispatch:

--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -1,0 +1,36 @@
+name: Windows ponyc update breakage test
+
+on:
+  repository_dispatch:
+    types: [ponyc-windows-nightly-released]
+
+permissions:
+  packages: read
+
+jobs:
+  windows:
+    name: Verify main against the latest ponyc on Windows
+    runs-on: windows-2025
+    steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+      - uses: actions/checkout@v6.0.2
+      - name: Test with most recent ponyc nightly
+        run: |
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Expand-Archive -Path C:\corral.zip -DestinationPath C:\corral;
+          $env:PATH = 'C:\ponyc\bin;C:\corral\bin;' + $env:PATH;
+          .\make.ps1 test
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.


### PR DESCRIPTION
Rename the existing breakage workflow to clarify it's Linux-only, and add a new Windows breakage test triggered by the ponyc Windows nightly release event.