### PR TITLE
Shuffle test order on Windows

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -162,8 +162,8 @@ switch ($Command.ToLower())
     }
 
     $testFile = (BuildTest)[-1]
-    Write-Host "$testFile"
-    & "$testFile"
+    Write-Host "$testFile --shuffle"
+    & "$testFile" --shuffle
     if ($LastExitCode -ne 0) { throw "Error" }
     break
   }


### PR DESCRIPTION
Add `--shuffle` to the Windows test runs in `make.ps1`, matching the Makefile change already on `main`. Windows builds and tests through `make.ps1`, not the Makefile, so the shuffle had to be added there too.
