### PR TITLE
Use make lint in pony-lint workflow

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint
-        run: pony-lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -58,6 +59,10 @@ $(docs_dir): $(SOURCE_FILES)
 
 docs: $(docs_dir)
 
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
+
 TAGS:
 	ctags --recurse=yes $(SRC_DIR)
 
@@ -66,4 +71,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all examples clean TAGS test test-one
+.PHONY: all examples clean lint TAGS test test-one


### PR DESCRIPTION
The workflow was calling pony-lint directly instead of going through the Makefile. Added a lint target that fetches dependencies via corral first, matching the pattern used across other ponylang projects.