### PR TITLE
Update to work with Pony 0.69.0

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,39 +17,39 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-release-linux:
-    name: Test against recent ponyc release on Linux
+  vs-ponyc-nightly-linux:
+    name: Test against recent ponyc nightly on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test
         run: make test config=debug
 
-  vs-ponyc-release-macOS-x86_64:
-    name: Test against recent ponyc release on x86-64 macOS
+  vs-ponyc-nightly-macOS-x86_64:
+    name: Test against recent ponyc nightly on x86-64 macOS
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Install dependencies
-        run: bash .ci-scripts/macOS-install-pony-tools.bash release
+        run: bash .ci-scripts/macOS-install-pony-tools.bash nightly
       - name: Test
         run: |
           export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
           make test config=debug
 
-  vs-ponyc-release-windows:
-    name: Test against recent ponyc release on Windows
+  vs-ponyc-nightly-windows:
+    name: Test against recent ponyc nightly on Windows
     runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\corral;
           $env:PATH = 'C:\corral\bin;' + $env:PATH;
           .\make.ps1 test

--- a/.release-notes/update-for-pony-0.69.0.md
+++ b/.release-notes/update-for-pony-0.69.0.md
@@ -1,0 +1,3 @@
+## Update to work with Pony 0.69.0
+
+Pony 0.69.0 is the new minimum required version.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Appdirs is an beta-level package.
 
 ## Installation
 
+* Requires ponyc 0.69.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/appdirs.git --version 0.1.5`
 * `corral fetch` to fetch your dependencies

--- a/appdirs/_test.pony
+++ b/appdirs/_test.pony
@@ -170,22 +170,22 @@ class \nodoc\ _AppDirsDefaultsTest is UnitTest
           where
             home_dir' = "/Users/ed",
             user_data_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             site_data_dirs' =
-              [ "/Library"
-                + "/Application Support/appdirs"
+              [ "/Library" +
+                "/Application Support/appdirs"
               ],
             user_config_dir' =
-              "/Users/ed/Library"
-                + "/Preferences/appdirs",
+              "/Users/ed/Library" +
+                "/Preferences/appdirs",
             site_config_dirs' =
               ["/Library/Preferences/appdirs"],
             user_cache_dir' =
               "/Users/ed/Library/Caches/appdirs",
             user_state_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             user_log_dir' =
               "/Users/ed/Library/Logs/appdirs")
       elseif windows then
@@ -207,9 +207,9 @@ class \nodoc\ _AppDirsDefaultsTest is UnitTest
             site_config_dirs' =
               ["C:\\ProgramData\\appdirs"],
             user_cache_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\Cache",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\Cache",
             user_state_dir' =
               u + "\\AppData\\Local\\appdirs",
             user_log_dir' =
@@ -256,31 +256,31 @@ class \nodoc\ _AppDirsVersionTest is UnitTest
           where
             home_dir' = "/Users/ed",
             user_data_dir' =
-              "/Users/ed/Library"
-                + "/Application Support"
-                + "/appdirs/0.4",
+              "/Users/ed/Library" +
+                "/Application Support" +
+                "/appdirs/0.4",
             site_data_dirs' =
-              [ "/Library"
-                + "/Application Support"
-                + "/appdirs/0.4"
+              [ "/Library" +
+                "/Application Support" +
+                "/appdirs/0.4"
               ],
             user_config_dir' =
-              "/Users/ed/Library"
-                + "/Preferences/appdirs/0.4",
+              "/Users/ed/Library" +
+                "/Preferences/appdirs/0.4",
             site_config_dirs' =
-              [ "/Library"
-                + "/Preferences/appdirs/0.4"
+              [ "/Library" +
+                "/Preferences/appdirs/0.4"
               ],
             user_cache_dir' =
-              "/Users/ed/Library"
-                + "/Caches/appdirs/0.4",
+              "/Users/ed/Library" +
+                "/Caches/appdirs/0.4",
             user_state_dir' =
-              "/Users/ed/Library"
-                + "/Application Support"
-                + "/appdirs/0.4",
+              "/Users/ed/Library" +
+                "/Application Support" +
+                "/appdirs/0.4",
             user_log_dir' =
-              "/Users/ed/Library"
-                + "/Logs/appdirs/0.4")
+              "/Users/ed/Library" +
+                "/Logs/appdirs/0.4")
       elseif windows then
         // hack for getting the username
         let user_name =
@@ -291,29 +291,29 @@ class \nodoc\ _AppDirsVersionTest is UnitTest
           where
             home_dir' = u,
             user_data_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\0.4",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\0.4",
             site_data_dirs' =
               ["C:\\ProgramData\\appdirs\\0.4"],
             user_config_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\0.4",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\0.4",
             site_config_dirs' =
               ["C:\\ProgramData\\appdirs\\0.4"],
             user_cache_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\Cache\\0.4",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\Cache\\0.4",
             user_state_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\0.4",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\0.4",
             user_log_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\0.4")
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\0.4")
       else
         _ExpectedAppDirs(
           where
@@ -352,8 +352,8 @@ class \nodoc\ _AppDirsNoHomeTest is UnitTest
             home_dir' = _ExpectError,
             user_data_dir' = _ExpectError,
             site_data_dirs' =
-              [ "/Library"
-                + "/Application Support/appdirs"
+              [ "/Library" +
+                "/Application Support/appdirs"
               ],
             user_config_dir' = _ExpectError,
             site_config_dirs' =
@@ -380,9 +380,9 @@ class \nodoc\ _AppDirsNoHomeTest is UnitTest
             site_config_dirs' =
               ["C:\\ProgramData\\appdirs"],
             user_cache_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\Cache",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\Cache",
             user_state_dir' =
               u + "\\AppData\\Local\\appdirs",
             user_log_dir' =
@@ -422,22 +422,22 @@ class \nodoc\ _AppDirsAppAuthorTest is UnitTest
           where
             home_dir' = "/Users/ed",
             user_data_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             site_data_dirs' =
-              [ "/Library"
-                + "/Application Support/appdirs"
+              [ "/Library" +
+                "/Application Support/appdirs"
               ],
             user_config_dir' =
-              "/Users/ed/Library"
-                + "/Preferences/appdirs",
+              "/Users/ed/Library" +
+                "/Preferences/appdirs",
             site_config_dirs' =
               ["/Library/Preferences/appdirs"],
             user_cache_dir' =
               "/Users/ed/Library/Caches/appdirs",
             user_state_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             user_log_dir' =
               "/Users/ed/Library/Logs/appdirs")
       elseif windows then
@@ -450,34 +450,34 @@ class \nodoc\ _AppDirsAppAuthorTest is UnitTest
           where
             home_dir' = u,
             user_data_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\Matthias Wahl\\appdirs",
+              u +
+                "\\AppData\\Local" +
+                "\\Matthias Wahl\\appdirs",
             site_data_dirs' =
-              [ "C:\\ProgramData"
-                + "\\Matthias Wahl\\appdirs"
+              [ "C:\\ProgramData" +
+                "\\Matthias Wahl\\appdirs"
               ],
             user_config_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\Matthias Wahl\\appdirs",
+              u +
+                "\\AppData\\Local" +
+                "\\Matthias Wahl\\appdirs",
             site_config_dirs' =
-              [ "C:\\ProgramData"
-                + "\\Matthias Wahl\\appdirs"
+              [ "C:\\ProgramData" +
+                "\\Matthias Wahl\\appdirs"
               ],
             user_cache_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\Matthias Wahl"
-                + "\\appdirs\\Cache",
+              u +
+                "\\AppData\\Local" +
+                "\\Matthias Wahl" +
+                "\\appdirs\\Cache",
             user_state_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\Matthias Wahl\\appdirs",
+              u +
+                "\\AppData\\Local" +
+                "\\Matthias Wahl\\appdirs",
             user_log_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\Matthias Wahl\\appdirs")
+              u +
+                "\\AppData\\Local" +
+                "\\Matthias Wahl\\appdirs")
       else
         _ExpectedAppDirs(
           where
@@ -520,22 +520,22 @@ class \nodoc\ _AppDirsWindowsRoamingTest is UnitTest
           where
             home_dir' = "/Users/ed",
             user_data_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             site_data_dirs' =
-              [ "/Library"
-                + "/Application Support/appdirs"
+              [ "/Library" +
+                "/Application Support/appdirs"
               ],
             user_config_dir' =
-              "/Users/ed/Library"
-                + "/Preferences/appdirs",
+              "/Users/ed/Library" +
+                "/Preferences/appdirs",
             site_config_dirs' =
               ["/Library/Preferences/appdirs"],
             user_cache_dir' =
               "/Users/ed/Library/Caches/appdirs",
             user_state_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             user_log_dir' =
               "/Users/ed/Library/Logs/appdirs")
       elseif windows then
@@ -558,9 +558,9 @@ class \nodoc\ _AppDirsWindowsRoamingTest is UnitTest
             site_config_dirs' =
               ["C:\\ProgramData\\appdirs"],
             user_cache_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\Cache",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\Cache",
             user_state_dir' =
               u + "\\AppData\\Roaming\\appdirs",
             user_log_dir' =
@@ -610,22 +610,22 @@ class \nodoc\ _AppDirsUnixXDGVarsTest is UnitTest
           where
             home_dir' = "/Users/ed",
             user_data_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             site_data_dirs' =
-              [ "/Library"
-                + "/Application Support/appdirs"
+              [ "/Library" +
+                "/Application Support/appdirs"
               ],
             user_config_dir' =
-              "/Users/ed/Library"
-                + "/Preferences/appdirs",
+              "/Users/ed/Library" +
+                "/Preferences/appdirs",
             site_config_dirs' =
               ["/Library/Preferences/appdirs"],
             user_cache_dir' =
               "/Users/ed/Library/Caches/appdirs",
             user_state_dir' =
-              "/Users/ed/Library"
-                + "/Application Support/appdirs",
+              "/Users/ed/Library" +
+                "/Application Support/appdirs",
             user_log_dir' =
               "/Users/ed/Library/Logs/appdirs")
       elseif windows then
@@ -647,9 +647,9 @@ class \nodoc\ _AppDirsUnixXDGVarsTest is UnitTest
             site_config_dirs' =
               ["C:\\ProgramData\\appdirs"],
             user_cache_dir' =
-              u
-                + "\\AppData\\Local"
-                + "\\appdirs\\Cache",
+              u +
+                "\\AppData\\Local" +
+                "\\appdirs\\Cache",
             user_state_dir' =
               u + "\\AppData\\Local\\appdirs",
             user_log_dir' =
@@ -671,8 +671,8 @@ class \nodoc\ _AppDirsUnixXDGVarsTest is UnitTest
             user_cache_dir' =
               "/home/ed/.kache/appdirs",
             user_state_dir' =
-              "/home/ed/home/ed/home/ed"
-                + "/.state/appdirs",
+              "/home/ed/home/ed/home/ed" +
+                "/.state/appdirs",
             user_log_dir' =
               "/home/ed/.kache/appdirs/log")
       end
@@ -716,8 +716,8 @@ class \nodoc\ _AppDirsOsxAsUnixTest is UnitTest
             user_cache_dir' =
               "/Users/ed/.kache/appdirs",
             user_state_dir' =
-              "/Users/ed/Users/ed/Users/ed"
-                + "/.state/appdirs",
+              "/Users/ed/Users/ed/Users/ed" +
+                "/.state/appdirs",
             user_log_dir' =
               "/Users/ed/.kache/appdirs/log")
       _AppDirsTestUtil.test(

--- a/appdirs/known_folders.pony
+++ b/appdirs/known_folders.pony
@@ -133,8 +133,8 @@ primitive KnownFolders
         )
       if result != 0 then
         Debug(
-          "Error getting known folder path: "
-            + result.string())
+          "Error getting known folder path: " +
+            result.string())
         error
       end
 


### PR DESCRIPTION
Fix pony-lint operator-spacing violations, declare ponyc 0.69.0 as the minimum required version, and switch PR CI to nightly until 0.69.0 releases.