### PR TITLE
Restore pre-release state after the lint-only 0.69.0 pass

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,39 +17,39 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-nightly-linux:
-    name: Test against recent ponyc nightly on Linux
+  vs-ponyc-release-linux:
+    name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test
         run: make test config=debug
 
-  vs-ponyc-nightly-macOS-x86_64:
-    name: Test against recent ponyc nightly on x86-64 macOS
+  vs-ponyc-release-macOS-x86_64:
+    name: Test against recent ponyc release on x86-64 macOS
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Install dependencies
-        run: bash .ci-scripts/macOS-install-pony-tools.bash nightly
+        run: bash .ci-scripts/macOS-install-pony-tools.bash release
       - name: Test
         run: |
           export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
           make test config=debug
 
-  vs-ponyc-nightly-windows:
-    name: Test against recent ponyc nightly on Windows
+  vs-ponyc-release-windows:
+    name: Test against recent ponyc release on Windows
     runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc nightly
+      - name: Test with most recent ponyc release
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\corral;
           $env:PATH = 'C:\corral\bin;' + $env:PATH;
           .\make.ps1 test

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,4 +1,0 @@
-## Update to work with Pony 0.69.0
-
-Pony 0.69.0 is the new minimum required version.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changed
 
-- Update to work with Pony 0.69.0 ([PR #111](https://github.com/ponylang/appdirs/pull/111))
 
 ## [0.1.5] - 2022-02-26
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Appdirs is an beta-level package.
 
 ## Installation
 
-* Requires ponyc 0.69.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/appdirs.git --version 0.1.5`
 * `corral fetch` to fetch your dependencies


### PR DESCRIPTION
The Pony 0.69.0 prep PR (#111) was lint fixes and CI configuration only; nothing user-facing changed. Removes the release note, the CHANGELOG entry, and the `Requires ponyc 0.69.0 or later` README bullet, and reverts pr.yml from :nightly back to :release (pony-lint.yml stays on :nightly because release pony-lint doesn't understand the new operator-spacing conventions).